### PR TITLE
COOK-4010: Check for service_running? should be more specific

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -152,7 +152,7 @@ end
 
 def service_running?
   begin
-    if shell_out(status_command).exitstatus == 0
+    if shell_out(status_command).stdout =~ /.*\(pid:\d+\):\sup/
       @current_resource.running true
       Chef::Log.debug("#{new_resource} is running")
     end

--- a/test/cookbooks/bluepill_test/files/default/tests/minitest/default_test.rb
+++ b/test/cookbooks/bluepill_test/files/default/tests/minitest/default_test.rb
@@ -23,20 +23,4 @@ describe_recipe 'bluepill_test::default' do
   it "the default log file must exist (COOK-1295)" do
     file(node['bluepill']['logfile']).must_exist
   end
-
-  describe "spawn a netcat tcp client repeatedly" do
-    let(:port) { node['bluepill_test']['tcp_server_listen_port'] }
-    let(:secret) { node['bluepill_test']['secret'] }
-    it "should receive a TCP connection from netcat" do
-      TCPServer.open("localhost", port) do |server|
-        client = server.accept
-        assert_instance_of TCPSocket, client
-
-        client_secret = client.gets.strip!
-        assert_equal secret, client_secret
-
-        client.close
-      end
-    end
-  end
 end

--- a/test/cookbooks/bluepill_test/recipes/default.rb
+++ b/test/cookbooks/bluepill_test/recipes/default.rb
@@ -18,3 +18,18 @@ template ::File.join(node['bluepill']['conf_dir'],
 bluepill_service node['bluepill_test']['service_name'] do
   action [:enable, :load, :start]
 end
+
+ruby_block "waiting for service to start" do
+  block do
+    command = Mixlib::ShellOut.new(
+      "#{node['bluepill']['bin']} #{node['bluepill_test']['service_name']} status")
+
+    result = command.run_command
+    unless result.stdout =~ /.*\(pid:\d+\):\sup/
+      raise "service not up"
+    end
+  end
+
+  retries 5
+  retry_delay 2
+end

--- a/test/cookbooks/bluepill_test/templates/default/test_app.pill.erb
+++ b/test/cookbooks/bluepill_test/templates/default/test_app.pill.erb
@@ -2,7 +2,7 @@
 Bluepill.application("test_app") do |app|
   app.process("netcat") do |process|
     process.pid_file = "/var/run/netcat.pid"
-    process.start_command = "sh -c 'echo <%= node['bluepill_test']['secret'] %> | " +
-      "nc -v localhost <%= node['bluepill_test']['tcp_server_listen_port'] %>'; sleep"
+    process.start_command = "nc -lk 1234"
+    process.daemonize = true
   end
 end


### PR DESCRIPTION
The service_running method was not correctly determining if the service was actually up.  The exit code of the bluepill status command seems to always return 0.  The change was to do a regex against the stdout of the status command.  This change broke the service.must_be_running test.  The existing tests was creating a pill file with a command that would never actually start but instead would exit with a non-zero exit code and continually be respawned by bluepill. This was the intention of the service, but because bluepill would always report "starting" instead of "up", the service was never considered up.

We removed the test that was listening for the secret being sent to the tcp port and just created a daemonized process that would stay running. We felt this was more testing bluepill's function of respawning a process than validating the functionality of the bluepill cookbook. Also, to ensure that the service is running before actually running the tests we make the test recipe block until the service is up.