### PR TITLE
Init scripts source an optional defaults file if it exists

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,10 +26,20 @@ case platform
 when "arch"
   default["bluepill"]["init_dir"] = "/etc/rc.d"
   default["bluepill"]["conf_dir"] = "/etc/bluepill"
+  default["bluepill"]["defaults_dir"] = "/etc/default"
 when "freebsd"
   default["bluepill"]["init_dir"] = "/usr/local/etc/rc.d"
   default["bluepill"]["conf_dir"] = "/usr/local/etc/bluepill"
+  default["bluepill"]["defaults_dir"] = "/etc/defaults"
 else
   default["bluepill"]["init_dir"] = "/etc/init.d"
   default["bluepill"]["conf_dir"] = "/etc/bluepill"
+
+  case platform
+  when "fedora","rhel"
+    default["bluepill"]["defaults_dir"] = "/etc/sysconfig"
+  when "debian","ubuntu"
+    default["bluepill"]["defaults_dir"] = "/etc/default"
+  end
+
 end

--- a/templates/default/bluepill_init.fedora.erb
+++ b/templates/default/bluepill_init.fedora.erb
@@ -12,6 +12,8 @@ BLUEPILL_BIN=<%= node['bluepill']['bin'] %>
 BLUEPILL_CONFIG=<%= @config_file %>
 SERVICE_NAME=<%= @service_name %>
 
+[ -r <%= node['bluepill']['defaults_dir'] %>/$SERVICE_NAME ] && . <%= node['bluepill']['defaults_dir'] %>/$SERVICE_NAME
+
 case "$1" in
   start)
     echo "Loading bluepill configuration for $SERVICE_NAME "

--- a/templates/default/bluepill_init.freebsd.erb
+++ b/templates/default/bluepill_init.freebsd.erb
@@ -24,6 +24,7 @@ status_cmd="${command} ${name} status"
 stop_cmd="${command} ${name} stop"
 stop_postcmd="${command} ${name} quit"
 
+[ -r <%= node['bluepill']['defaults_dir'] %>/$name ] && . <%= node['bluepill']['defaults_dir'] %>/$name
 load_rc_config ${name}
 
 PATH="${PATH}:/usr/local/bin"

--- a/templates/default/bluepill_init.lsb.erb
+++ b/templates/default/bluepill_init.lsb.erb
@@ -12,6 +12,8 @@ BLUEPILL_BIN=<%= node['bluepill']['bin'] %>
 BLUEPILL_CONFIG=<%= @config_file %>
 SERVICE_NAME=<%= @service_name %>
 
+[ -r <%= node['bluepill']['defaults_dir'] %>/$SERVICE_NAME ] && . <%= node['bluepill']['defaults_dir'] %>/$SERVICE_NAME
+
 case "$1" in
   start)
     echo "Loading bluepill configuration for $SERVICE_NAME "

--- a/templates/default/bluepill_init.rhel.erb
+++ b/templates/default/bluepill_init.rhel.erb
@@ -12,6 +12,8 @@ BLUEPILL_BIN=<%= node['bluepill']['bin'] %>
 BLUEPILL_CONFIG=<%= @config_file %>
 SERVICE_NAME=<%= @service_name %>
 
+[ -r <%= node['bluepill']['defaults_dir'] %>/$SERVICE_NAME ] && . <%= node['bluepill']['defaults_dir'] %>/$SERVICE_NAME
+
 case "$1" in
   start)
     echo "Loading bluepill configuration for $SERVICE_NAME "


### PR DESCRIPTION
This helpful addition allows services to inject optional configurations into the initialization script, following common distribution standards:
* [/etc/default/$SERVICE_NAME for Debian](https://www.debian.org/doc/debian-policy/ch-opersys.html#s-writing-init)
* [/etc/sysconfig/$SERVICE_NAME for Fedora](http://fedoraproject.org/wiki/Packaging:SysVInitScript#Initscript_packaging) and RHEL
* [/etc/defaults/$name for FreeBSD](https://www.freebsd.org/doc/handbook/configtuning-configfiles.html)


